### PR TITLE
Install PHP XDebug extension

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -88,6 +88,7 @@ php::module { 'php5-memcache': }
 php::module { 'php5-memcached': }
 php::module { 'php5-suhosin': }
 php::module { 'php-apc': }
+php::module { 'php5-xdebug': }
 
 class { 'php::devel':
   require => Class['php'],


### PR DESCRIPTION
This is used for code coverage in the OT Booking System. The new config line installs and configures the extension so it's ready to use straight away.

Ensure your VM is up, and then just run `vagrant provision` to install it.
